### PR TITLE
Install `jupyterlite` from PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,7 @@ jobs:
           python-version: 3.8
       - name: Install the dependencies
         run: |
-          python -m pip install -U pip setuptools jupyterlab~=3.3
-          python -m pip install ./docs/jupyterlite-0.1.0b0.tar.gz
+          python -m pip install -U pip setuptools jupyterlab~=3.3 jupyterlite
           python -m pip install -e .
           jupyter labextension develop . --overwrite
       - name: Build the JupyterLite site


### PR DESCRIPTION
Update the deploy script to install `jupyterlite` from PyPI.

This should pull `0.1.0b2` (latest at the moment), which includes the fix you submitted in https://github.com/jupyterlite/jupyterlite/pull/532 @trungleduc.

https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b2