### PR TITLE
Automated Changelog Entry for 0.5.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.5.0
+
+([Full Changelog](https://github.com/trungleduc/jupyterview/compare/v0.4.0...a390c8e11729feba8819712ee2bada58a26b922f))
+
+### Enhancements made
+
+- Read mesh  files using MeshIO [#34](https://github.com/trungleduc/jupyterview/pull/34) ([@trungleduc](https://github.com/trungleduc))
+- Install `jupyterlite` from PyPI [#31](https://github.com/trungleduc/jupyterview/pull/31) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Bump moment from 2.29.1 to 2.29.2 [#33](https://github.com/trungleduc/jupyterview/pull/33) ([@dependabot](https://github.com/dependabot))
+- Bump minimist from 1.2.5 to 1.2.6 [#32](https://github.com/trungleduc/jupyterview/pull/32) ([@dependabot](https://github.com/dependabot))
+- Bump follow-redirects from 1.14.7 to 1.14.9 [#29](https://github.com/trungleduc/jupyterview/pull/29) ([@dependabot](https://github.com/dependabot))
+- Bump url-parse from 1.5.4 to 1.5.10 [#28](https://github.com/trungleduc/jupyterview/pull/28) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/trungleduc/jupyterview/graphs/contributors?from=2022-03-06&to=2022-06-10&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Atrungleduc%2Fjupyterview+involves%3Adependabot+updated%3A2022-03-06..2022-06-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Atrungleduc%2Fjupyterview+involves%3Ajtpio+updated%3A2022-03-06..2022-06-10&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fjupyterview+involves%3Atrungleduc+updated%3A2022-03-06..2022-06-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.0
 
 ([Full Changelog](https://github.com/trungleduc/jupyterview/compare/v0.1.0...d017da4605943948bdbf08dd9cc51c7cdef1a02b))
@@ -15,5 +39,3 @@
 ([GitHub contributors page for this release](https://github.com/trungleduc/jupyterview/graphs/contributors?from=2021-06-15&to=2022-03-06&type=c))
 
 [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fjupyterview+involves%3Atrungleduc+updated%3A2021-06-15..2022-03-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.5.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | trungleduc/jupyterview  |
| Branch  | master  |
| Version Spec | 0.5.0 |
| Since | v0.4.0 |